### PR TITLE
Replace caskroom.io link and reword sentence

### DIFF
--- a/source/localizable/download.html.slim
+++ b/source/localizable/download.html.slim
@@ -56,8 +56,8 @@ section#downloads.downloads
             h5 Install via Homebrew Cask
             p.text-muted
                 | You may also install IINA via the community-maintained&nbsp;
-                = link_to 'Homebrew Cask', 'http://caskroom.io/'
-                | &nbsp;formula by running:
+                = link_to 'Homebrew', 'https://brew.sh/'
+                | &nbsp;cask by running:
             pre.bg-light.p-2.text-center
                 | brew cask install iina
     section#browser-extension.mt-5


### PR DESCRIPTION
Neither the Homebrew or former Caskroom team has control over the caskroom.io domain anymore — https://github.com/Homebrew/homebrew-cask/issues/51928#issuecomment-421189147.

Homebrew Cask doesn't use formulas either, the Ruby files themselves are the _"casks"_.