### PR TITLE
Correct phonemic transcription of IINA

### DIFF
--- a/source/localizable/index.html.slim
+++ b/source/localizable/index.html.slim
@@ -13,7 +13,7 @@ section.title
     .container.position-relative
         .sample-image
             = image_tag "sc-sky.png", alt: "Screenshot"
-        .small-headline = "/ˈiːnʌ/"
+        .small-headline = "/ˈiːnə/"
         h1.headline
             | IINA
         p.sub-headline


### PR DESCRIPTION
`/ʌ/` only appears in stressed positions in English, and never word-finally. The vowel you're looking for is `/ə/`. (Even if your dialect merges the two, the merged vowel is usually represented as `/ə/`, so representing IINA as `/ˈiːnʌ/` is nonsensical.)