### PR TITLE
Fix Incorrect Year In Footer

### DIFF
--- a/source/_footer.slim
+++ b/source/_footer.slim
@@ -2,7 +2,7 @@ footer
     .container
         .contact.mb-2.d-flex.justify-content-between
             .left
-                span &copy;2018-2019 iina.io
+                span &copy;2018-2024 iina.io
             .right
                 span.fas.fa-envelope.mr-2
                 span


### PR DESCRIPTION
It seems that the footer wasn't modified since the initial commit, however it still show "©2018-2019 iina.io". I changed it into "©2018-2024 iina.io" to make it correct.
