### PR TITLE
Correct #browser-extensions section id to match the link in index.htm…

### DIFF
--- a/source/localizable/download.html.slim
+++ b/source/localizable/download.html.slim
@@ -84,7 +84,7 @@ section#downloads.downloads
                 | &nbsp;cask by running:
             pre.bg-light.p-2.text-center
                 | brew install --cask iina
-    section#browser-extension.mt-5
+    section#browser-extensions.mt-5
         .container
             h5 Browser extensions
             p.text-muted


### PR DESCRIPTION
The link:

https://github.com/iina/iina-website/blob/5cbb9b429d461c135e3b5960bfb80beffc0d5274/source/localizable/index.html.slim#L114

and the target:

https://github.com/iina/iina-website/blob/5cbb9b429d461c135e3b5960bfb80beffc0d5274/source/localizable/download.html.slim#L87

This pull request adds a `s` to the latter so the link works as intended