### PR TITLE
Fix download layout breaks on mobile

### DIFF
--- a/source/localizable/download.html.slim
+++ b/source/localizable/download.html.slim
@@ -20,7 +20,7 @@ section#downloads.downloads
                     = latest.date
                     = link_to release_note_link(latest.version), class: 'release-note ml-2', target: '_blank' do
                         = t(:release_note)
-                .text-muted.small.mt-2
+                .text-muted.small.mt-2.break-all
                     | SHA256:
                     = latest.sha256
                 .small


### PR DESCRIPTION
Download page looks like this on mobile:
<img width="472" alt="image" src="https://github.com/user-attachments/assets/6eebf35c-8046-4d13-8f25-d2bcf545cfbb">
Because hash is to wide.

I added `break-all` so it would go to the second line if width is smaller.
<img width="388" alt="image" src="https://github.com/user-attachments/assets/96394b73-fc70-4414-8b8d-e6e4849c5521">
